### PR TITLE
Fix #4 - Remove underscore dependency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 var clc = require("cli-color");
-var _ = require("underscore");
 
 var startSymbol = String.fromCharCode(10033);
 var doneSymbol = String.fromCharCode(10004);
@@ -141,13 +140,14 @@ module.exports = conzole;
 function getArgumentsAsString(args) {
     var response = [];
 
-    _.each(args, function(arg) {
+    for (var a in args) {
+        var arg = args[a];
         if (typeof arg === "object") {
             response.push(JSON.stringify(arg));
         } else {
             response.push(arg);
         }
-    });
+    }
     return response.join(" ");
 }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "author": "Sebastien Moran (sebz)",
   "license": "ISC",
   "dependencies": {
-    "cli-color": "^0.2.3",
-    "underscore": "^1.7.0"
+    "cli-color": "^0.2.3"
   }
 }


### PR DESCRIPTION
Use native `for ... in` loop instead of depending on an external dependency